### PR TITLE
Give a type to skills

### DIFF
--- a/tap_zendesk_chat/schemas/agents.json
+++ b/tap_zendesk_chat/schemas/agents.json
@@ -74,7 +74,10 @@
       "type": [
         "null",
         "array"
-      ]
+      ],
+      "items": {
+        "type": "integer"
+      }
     },
     "email": {
       "type": [


### PR DESCRIPTION
There was an "array" in one of the JSON schemas that did not have an "items" key in its schema. I found where it was located using this script:

```python
import json


with open("catalog.json") as f:
    catalog = json.loads(f.read())

def walkit(x, path=[]):
    if type(x) == dict:
        if "type" in x:
            types = x["type"] if isinstance(x["type"], list) else [x["type"]]
            if "array" in types and "items" not in x:
                print("FOUND AT ", path)
        for k, v in x.items():
            walkit(v, path + [k])
    elif type(x) == list:
        for i, v in enumerate(x):
            walkit(v, path + [i])


for stream in catalog["streams"]:
    schema = stream["schema"]
    walkit(schema, [stream["tap_stream_id"]])
```

I added a skill to an agent in Zopim and discovered the items should be integers.