### PR TITLE
Upgrade singer-python, add inclusion field to schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,8 @@ setup(name="tap-zendesk-chat",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_zendesk_chat"],
       install_requires=[
-          "singer-python>=3.2.0",
+          "singer-python==3.5.0",
           "requests",
-          "backoff",
-          "attrs",
       ],
       entry_points="""
           [console_scripts]

--- a/tap_zendesk_chat/__init__.py
+++ b/tap_zendesk_chat/__init__.py
@@ -34,7 +34,7 @@ def discover():
     for stream in all_streams:
         schema = Schema.from_dict(load_schema(stream.tap_stream_id),
                                   inclusion="automatic")
-        schema.selected = True
+        schema.selected = False
         catalog.streams.append(CatalogEntry(
             stream=stream.tap_stream_id,
             tap_stream_id=stream.tap_stream_id,

--- a/tap_zendesk_chat/__init__.py
+++ b/tap_zendesk_chat/__init__.py
@@ -34,7 +34,6 @@ def discover():
     for stream in all_streams:
         schema = Schema.from_dict(load_schema(stream.tap_stream_id),
                                   inclusion="automatic")
-        schema.selected = False
         catalog.streams.append(CatalogEntry(
             stream=stream.tap_stream_id,
             tap_stream_id=stream.tap_stream_id,

--- a/tap_zendesk_chat/__init__.py
+++ b/tap_zendesk_chat/__init__.py
@@ -6,7 +6,7 @@ import json
 from .streams import all_streams, all_stream_ids
 from .context import Context
 from collections import namedtuple
-from singer.catalog import Catalog
+from singer.catalog import Catalog, CatalogEntry, Schema
 
 REQUIRED_CONFIG_KEYS = ["start_date", "access_token"]
 LOGGER = singer.get_logger()
@@ -30,16 +30,18 @@ def load_schema(tap_stream_id):
 
 def discover():
     result = {"streams": []}
+    catalog = Catalog([])
     for stream in all_streams:
-        schema = load_schema(stream.tap_stream_id)
-        schema["selected"] = False
-        result["streams"].append(
-            dict(stream=stream.tap_stream_id,
-                 tap_stream_id=stream.tap_stream_id,
-                 key_properties=stream.pk_fields,
-                 schema=schema)
-        )
-    return Catalog.from_dict(result)
+        schema = Schema.from_dict(load_schema(stream.tap_stream_id),
+                                  inclusion="automatic")
+        schema.selected = True
+        catalog.streams.append(CatalogEntry(
+            stream=stream.tap_stream_id,
+            tap_stream_id=stream.tap_stream_id,
+            key_properties=stream.pk_fields,
+            schema=schema,
+        ))
+    return catalog
 
 
 def output_schema(stream):

--- a/tap_zendesk_chat/streams.py
+++ b/tap_zendesk_chat/streams.py
@@ -3,7 +3,6 @@ from pendulum import parse as dt_parse
 import time
 from datetime import datetime, timedelta
 from requests.exceptions import HTTPError
-import attr
 import json
 import singer
 


### PR DESCRIPTION
Adds the "inclusion" property to the schemas

resulting schema:
[catalog.json.txt](https://github.com/singer-io/tap-zendesk-chat/files/1330347/catalog.json.txt)

Can you confirm this is what you expect:

- The "selected" property is False by default
- "selected" is only found at the root of each json schema. For example:

```
 $  cat catalog.json | jq '.streams | first | .schema.selected'
false
```

but

```
 $  cat catalog.json | jq '.streams | first | .schema.properties | values[].selected'
null
null
null
null
null
null
null
null
null
null
null
null
```

- "inclusion" is "automatic" and set for every node in the schema:

```
 $  cat catalog.json | jq '.streams | first | .schema.properties | values[].inclusion'
"automatic"
"automatic"
"automatic"
"automatic"
"automatic"
"automatic"
"automatic"
"automatic"
"automatic"
"automatic"
"automatic"
"automatic"
```

I ran the tests in https://github.com/stitchdata/tap-tester/pull/7 with these changes