### PR TITLE
implement connection check during discovery

### DIFF
--- a/tap_zendesk_chat/__init__.py
+++ b/tap_zendesk_chat/__init__.py
@@ -2,11 +2,11 @@
 import os
 import singer
 from singer import metrics, utils
-import json
-from .streams import all_streams, all_stream_ids
-from .context import Context
-from collections import namedtuple
 from singer.catalog import Catalog, CatalogEntry, Schema
+from requests.exceptions import HTTPError
+from . import streams as streams_
+from .context import Context
+from .http import Client
 
 REQUIRED_CONFIG_KEYS = ["start_date", "access_token"]
 LOGGER = singer.get_logger()
@@ -28,10 +28,38 @@ def load_schema(tap_stream_id):
     return schema
 
 
-def discover():
-    result = {"streams": []}
+def ensure_credentials_are_authorized(client):
+    # The request will throw an exception if the credentials are not authorized
+    client.request(streams_.DEPARTMENTS.tap_stream_id)
+
+
+def is_account_endpoint_authorized(client):
+    # The account endpoint is restricted to zopim accounts, meaning integrated
+    # Zendesk accounts will get a 403 for this endpoint.
+    try:
+        client.request(streams_.ACCOUNT.tap_stream_id)
+    except HTTPError as e:
+        if e.response.status_code == 403:
+            LOGGER.info(
+                "Ignoring 403 from account endpoint - this must be an "
+                "integrated Zendesk account. This endpoint will be excluded "
+                "from discovery."
+            )
+            return False
+        else:
+            raise
+    return True
+
+
+def discover(config):
+    client = Client(config)
+    ensure_credentials_are_authorized(client)
+    include_account_stream = is_account_endpoint_authorized(client)
     catalog = Catalog([])
-    for stream in all_streams:
+    for stream in streams_.all_streams:
+        if (not include_account_stream
+            and stream.tap_stream_id == streams_.ACCOUNT.tap_stream_id):
+            continue
         schema = Schema.from_dict(load_schema(stream.tap_stream_id),
                                   inclusion="automatic")
         catalog.streams.append(CatalogEntry(
@@ -50,11 +78,11 @@ def output_schema(stream):
 
 def sync(ctx):
     currently_syncing = ctx.state.get("currently_syncing")
-    start_idx = all_stream_ids.index(currently_syncing) \
+    start_idx = streams_.all_stream_ids.index(currently_syncing) \
         if currently_syncing else 0
     stream_ids_to_sync = [cs.tap_stream_id for cs in ctx.catalog.streams
                           if cs.is_selected()]
-    streams = [s for s in all_streams[start_idx:]
+    streams = [s for s in streams_.all_streams[start_idx:]
                if s.tap_stream_id in stream_ids_to_sync]
     for stream in streams:
         ctx.state["currently_syncing"] = stream.tap_stream_id
@@ -68,11 +96,11 @@ def sync(ctx):
 def main():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     if args.discover:
-        discover().dump()
+        discover(args.config).dump()
         print()
     else:
         catalog = Catalog.from_dict(args.properties) \
-            if args.properties else discover()
+            if args.properties else discover(args.config)
         ctx = Context(args.config, args.state, catalog)
         sync(ctx)
 


### PR DESCRIPTION
And also redo handling of the "account" endpoint so that we exclude the stream during discovery if we get a 403 for it. This is because integrated zendesk accounts do not support this endpoint, but straight up Zopim accounts do.