### PR TITLE
Additional chat search pagination

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ setup(name="tap-zendesk-chat",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_zendesk_chat"],
       install_requires=[
+          "python-dateutil==2.6.0",  # because of singer-python issue
+          "pendulum==1.2.0",  # because of singer-python issue
           "singer-python==3.5.0",
           "requests",
       ],

--- a/tap_zendesk_chat/context.py
+++ b/tap_zendesk_chat/context.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from .http import Client
 import singer
 from datetime import datetime
@@ -9,6 +10,7 @@ class Context(object):
         self.state = state
         self.catalog = catalog
         self.client = Client(config)
+        self.now = datetime.utcnow()
 
     @property
     def bookmarks(self):

--- a/tap_zendesk_chat/streams.py
+++ b/tap_zendesk_chat/streams.py
@@ -103,7 +103,7 @@ class Chats(Stream):
         start_time = ctx.update_start_date_bookmark(ts_bookmark_key)
         next_url = ctx.bookmark(url_offset_key)
         max_bookmark = start_time
-        interval_days = ctx.config.get("chats_interval_days", 90)
+        interval_days = ctx.config.get("chats_interval_days", 60)
         intervals = break_into_intervals(interval_days, start_time, ctx.now)
         for start_dt, end_dt in intervals:
             while True:

--- a/tap_zendesk_chat/streams.py
+++ b/tap_zendesk_chat/streams.py
@@ -9,10 +9,10 @@ LOGGER = singer.get_logger()
 
 
 def break_into_intervals(days, start_time: str, now: datetime):
-    interval = timedelta(days=days)
+    delta = timedelta(days=days)
     start_dt = dt_parse(start_time)
     while start_dt < now:
-        end_dt = min(start_dt + interval, now)
+        end_dt = min(start_dt + delta, now)
         yield start_dt, end_dt
         start_dt = end_dt
 
@@ -103,7 +103,7 @@ class Chats(Stream):
         start_time = ctx.update_start_date_bookmark(ts_bookmark_key)
         next_url = ctx.bookmark(url_offset_key)
         max_bookmark = start_time
-        interval_days = ctx.config.get("chats_interval_days", 60)
+        interval_days = ctx.config.get("chat_search_interval_days", 60)
         intervals = break_into_intervals(interval_days, start_time, ctx.now)
         for start_dt, end_dt in intervals:
             while True:

--- a/test/test_streams.py
+++ b/test/test_streams.py
@@ -1,0 +1,14 @@
+import pendulum
+from tap_zendesk_chat.streams import break_into_intervals
+
+
+def test_intervals():
+    days = 30
+    now = pendulum.parse("2018-02-14T10:30:20")
+    broken = break_into_intervals(days, "2018-01-02T18:14:33", now)
+    as_strs = [(x.isoformat(), y.isoformat()) for x, y in broken]
+    assert as_strs == [
+        ("2018-01-02T18:14:33+00:00", "2018-02-01T18:14:33+00:00"),
+        ("2018-02-01T18:14:33+00:00", "2018-02-14T10:30:20+00:00"),
+    ]
+


### PR DESCRIPTION
Fixes #6  - see discussion for details

Testing:

Synced `chats` on master and in this branch and confirmed they have the same number of records, but this branch performed more searches.

Did another search with a search interval of 1 day with a test account where there are multiple chats spanning several days. Once again the data is all there.

Also ran with an updated state.json file and confirmed a small number of chats synced.