### PR TITLE
Fix/Convert custom interval days to int

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ config.json
 
 rsa-key
 tags
+properties.json

--- a/tap_zendesk_chat/streams.py
+++ b/tap_zendesk_chat/streams.py
@@ -103,7 +103,13 @@ class Chats(Stream):
         start_time = ctx.update_start_date_bookmark(ts_bookmark_key)
         next_url = ctx.bookmark(url_offset_key)
         max_bookmark = start_time
-        interval_days = ctx.config.get("chat_search_interval_days", 14)
+
+        interval_days = 14
+        interval_days_str = ctx.config.get("chat_search_interval_days")
+        if interval_days_str is not None:
+            interval_days = int(interval_days_str)
+        LOGGER.info("Using chat_search_interval_days: {}".format(interval_days))
+
         intervals = break_into_intervals(interval_days, start_time, ctx.now)
         for start_dt, end_dt in intervals:
             while True:


### PR DESCRIPTION
When we specify a `chat_search_interval_days` value in the config, it will always be a string. This updates the tap to support both integer and string values.