### PR TITLE
add enabled_departments

### DIFF
--- a/tap_zendesk_chat/schemas/agents.json
+++ b/tap_zendesk_chat/schemas/agents.json
@@ -65,6 +65,12 @@
         "boolean"
       ]
     },
+    "enabled_departments": {
+      "type": [
+        "null",
+        "array"
+      ]
+    },
     "departments": {
       "items": {
         "type": [


### PR DESCRIPTION
# Description of change
Adds `enabled_departments` as a non-mandatory array

[source](https://developer.zendesk.com/rest_api/docs/chat/agents)

References issue: #26 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
