### PR TITLE
Bump/v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 ## 0.3.0
-  * Added field selection support [#29](https://github.com/singer-io/tap-zendesk-chat/pull/29)
+  * Adds field selection via transformer and increases singer-python version to `5.12.1` [#32](https://github.com/singer-io/tap-zendesk-chat/pull/32)
+  * Adds bookmarking test [#31](https://github.com/singer-io/tap-zendesk-chat/pull/31)
+  * Fixes schemas to not include `additionalProperties` and adds start date test[#30](https://github.com/singer-io/tap-zendesk-chat/pull/30)
+  * Changes metadata to allow `inclusion: available` to support field selection and adds discovery test[#29](https://github.com/singer-io/tap-zendesk-chat/pull/29)
 
 ## 0.2.1
   * Added `enabled_departments` to the JSON Schema for agents [#27](https://github.com/singer-io/tap-zendesk-chat/pull/27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.0
+  * Added field selection support [#29](https://github.com/singer-io/tap-zendesk-chat/pull/29)
+
 ## 0.2.1
   * Added `enabled_departments` to the JSON Schema for agents [#27](https://github.com/singer-io/tap-zendesk-chat/pull/27)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-zendesk-chat",
-      version="0.2.1",
+      version="0.3.0",
       description="Singer.io tap for extracting data from the Zendesk Chat API",
       author="Stitch",
       url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name="tap-zendesk-chat",
       install_requires=[
           "python-dateutil==2.6.0",  # because of singer-python issue
           "pendulum==1.2.0",  # because of singer-python issue
-          "singer-python==5.0.3",
+          "singer-python==5.12.1",
           "requests==2.20.0",
       ],
       extras_require={


### PR DESCRIPTION
# Description of change
## 0.3.0
  * Adds field selection via transformer and increases singer-python version to `5.12.1` [#32](https://github.com/singer-io/tap-zendesk-chat/pull/32)
  * Adds bookmarking test [#31](https://github.com/singer-io/tap-zendesk-chat/pull/31)
  * Fixes schemas to not include `additionalProperties` and adds start date test[#30](https://github.com/singer-io/tap-zendesk-chat/pull/30)
  * Changes metadata to allow `inclusion: available` to support field selection and adds discovery test[#29](https://github.com/singer-io/tap-zendesk-chat/pull/29)

# Manual QA steps
 - 
 
# Risks
 - High, we are marking fields as `available` instead of `automatic`, any connections that were migrated improperly would lose their selected fields
 - quite a few code changes, including adding the transformer and bumping singer-python
 
# Rollback steps
 - revert this branch
