### PR TITLE
Chats Stream Failing Due to Timestamp

### DIFF
--- a/tap_zendesk_chat/streams.py
+++ b/tap_zendesk_chat/streams.py
@@ -145,7 +145,7 @@ class Chats(BaseStream):
                 if next_url:
                     search_resp = ctx.client.request(self.tap_stream_id, url=next_url)
                 else:
-                    params = {"q": f"type:{chat_type} AND {ts_field}:[{start_dt.isoformat()} TO {end_dt.isoformat()}]"}
+                    params = {"q": f"type:{chat_type} AND {ts_field}:[{start_dt.replace(tzinfo=None).isoformat()} TO {end_dt.replace(tzinfo=None).isoformat()}]"}
                     search_resp = ctx.client.request(self.tap_stream_id, params=params, url_extra="/search")
 
                 next_url = search_resp["next_url"]


### PR DESCRIPTION
# Description of change
The chats endpoint has began to fail due to the timezone info being present in the search query. This PR aims to remove the timezone info.

We were getting the error:
```
2025-01-13T15:57:10.471337Z [info     ] INFO calling https://www.zopim.com/api/v2/chats/search {'q': 'type:chat AND end_timestamp:[2024-12-02T00:00:00+00:00 TO 2024-12-07T00:00:00+00:00]'} cmd_type=elb consumer=False name=tap-zendesk-chat producer=True stdio=stderr string_id=tap-zendesk-chat
2025-01-13T15:57:10.770311Z [info     ] INFO METRIC: {"type": "timer", "metric": "http_request_duration", "value": 0.7818355560302734, "tags": {"endpoint": "chats", "http_status_code": 400, "status": "succeeded"}} cmd_type=elb consumer=False name=tap-zendesk-chat producer=True stdio=stderr string_id=tap-zendesk-chat
2025-01-13T15:57:10.770618Z [info     ] WARNING The amount of data present for in %s stream is huge,                The api has a pagination limit of 251 pages, please reduce the search window for this stream cmd_type=elb consumer=False name=tap-zendesk-chat producer=True stdio=stderr string_id=tap-zendesk-chat
2025-01-13T15:57:10.770737Z [info     ] CRITICAL 400 Client Error: Bad Request for url: https://www.zopim.com/api/v2/chats/search?q=type%3Achat+AND+end_timestamp%3A%5B2024-12-02T00%3A00%3A00%2B00%3A00+TO+2024-12-07T00%3A00%3A00%2B00%3A00%5D cmd_type=elb consumer=False name=tap-zendesk-chat producer=True stdio=stderr string_id=tap-zendesk-chat
```

First step towards fixing was reducing the `agents_page_limit` and the `chat_search_interval_days`. After neither of those worked I tried inputing the the search query `type:chat AND end_timestamp:[2024-12-02T00:00:00+00:00 TO 2024-12-07T00:00:00+00:00]` in postman and received an error `400 Bad Request`. After removing the the timezone info the query worked `type:chat AND end_timestamp:[2024-12-02T00:00:00 TO 2024-12-07T00:00:00]`

# Manual QA steps
 - Modified the python within our project and tested.

# Risks
 - Could affect the state and how we expect the search time to work.

# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool
