### PR TITLE
Fail fast when discovery/auth fails to prevent false Completed runs

### DIFF
--- a/tap_zendesk_chat/__init__.py
+++ b/tap_zendesk_chat/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import singer
-from singer.utils import handle_top_exception, parse_args
+from singer.utils import parse_args
 
 from .context import Context
 from .discover import discover
@@ -10,15 +10,18 @@ REQUIRED_CONFIG_KEYS = ["start_date", "access_token"]
 LOGGER = singer.get_logger()
 
 
-@handle_top_exception(LOGGER)
 def main():
     """performs sync and discovery."""
-    args = parse_args(REQUIRED_CONFIG_KEYS)
-    if args.discover:
-        discover(args.config).dump()
-    else:
-        ctx = Context(args.config, args.state, args.catalog or discover(args.config))
-        sync(ctx)
+    try:
+        args = parse_args(REQUIRED_CONFIG_KEYS)
+        if args.discover:
+            discover(args.config).dump()
+        else:
+            ctx = Context(args.config, args.state, args.catalog or discover(args.config))
+            sync(ctx)
+    except Exception as err:
+        LOGGER.critical("Fatal error in tap-zendesk-chat", exc_info=True)
+        raise SystemExit(1) from err
 
 
 if __name__ == "__main__":

--- a/tap_zendesk_chat/discover.py
+++ b/tap_zendesk_chat/discover.py
@@ -18,9 +18,9 @@ def account_not_authorized(client):
     except HTTPError as err:
         if err.response.status_code == 403:
             LOGGER.info(
-                "Ignoring 403 from account endpoint - this must be an \
-                integrated Zendesk account. This endpoint will be excluded \
-                from discovery"
+                "Ignoring 403 from account endpoint - this must be an "
+                "integrated Zendesk account. This endpoint will be excluded "
+                "from discovery"
             )
             return True
         raise

--- a/tap_zendesk_chat/http.py
+++ b/tap_zendesk_chat/http.py
@@ -65,8 +65,9 @@ class Client:
             raise RateLimitException()
         elif response.status_code == 400:
             LOGGER.warning(
-                "The amount of data present for in %s stream is huge,\
-                The api has a pagination limit of 251 pages, please reduce the search window for this stream"
+                "The amount of data present for in %s stream is huge. "
+                "The api has a pagination limit of 251 pages, please reduce the search window for this stream",
+                tap_stream_id
             )
         response.raise_for_status()
         return response.json()

--- a/tests/unittests/test_main.py
+++ b/tests/unittests/test_main.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest import mock
+
+import tap_zendesk_chat
+from tap_zendesk_chat.http import InvalidConfigurationError
+
+
+class Args:
+    discover = False
+    config = {"access_token": "token", "start_date": "2022-01-01T00:00:00Z"}
+    state = {}
+    catalog = {}
+
+
+class TestMainErrorHandling(unittest.TestCase):
+    @mock.patch("tap_zendesk_chat.parse_args", return_value=Args())
+    @mock.patch("tap_zendesk_chat.sync", side_effect=RuntimeError("sync failed"))
+    @mock.patch("tap_zendesk_chat.Context", return_value=object())
+    def test_main_sync_failure_exits_nonzero(self, _mock_context, _mock_sync, _mock_parse_args):
+        with self.assertRaises(SystemExit) as err:
+            tap_zendesk_chat.main()
+        self.assertEqual(1, err.exception.code)
+
+    @mock.patch("tap_zendesk_chat.parse_args")
+    @mock.patch("tap_zendesk_chat.discover", side_effect=InvalidConfigurationError("bad credentials"))
+    def test_main_discovery_failure_exits_nonzero(self, _mock_discover, mock_parse_args):
+        args = Args()
+        args.discover = True
+        mock_parse_args.return_value = args
+
+        with self.assertRaises(SystemExit) as err:
+            tap_zendesk_chat.main()
+        self.assertEqual(1, err.exception.code)


### PR DESCRIPTION
## Summary
- Fixes failure propagation for discovery/auth errors (including 401) that could appear as Completed with zero batches.
- Forces non-zero process exit on fatal discovery or sync exceptions so orchestration marks the task as failed.

## Root Cause
- Discovery/auth errors were not consistently surfaced as hard runtime failures for orchestration.
- This could emit extraction.ended with zero batches and no dataset batch events, leaving datasets queued.

## What Changed
- Updated tap_zendesk_chat/__init__.py to catch fatal exceptions and exit with code 1.
- Added tests/unittests/test_main.py to verify non-zero exit for discovery and sync failures.

## Before / After
- Before: task could look Completed while monitor datasets stayed queued.
- After: discovery/auth failure exits non-zero and is surfaced as a task failure.

## Validation
- Added targeted unit tests for main error handling paths.
- Local execution here is dependency-limited (missing singer/requests), but changed files are clean in diagnostics.
